### PR TITLE
Add Power Query functions for accessing local Exercism data

### DIFF
--- a/src/local-api/ExercismReposRootPath.pq
+++ b/src/local-api/ExercismReposRootPath.pq
@@ -1,0 +1,40 @@
+// File: ExercismReposRootPath.pq
+// Description: This query defines a Power Query parameter for the local file system path
+//              to a root directory where various Exercism repositories (e.g., 'problem-specifications',
+//              track repositories like 'awk', 'bash') are cloned.
+//              It allows other queries to access files from these local clones.
+//
+// How to Use:
+// 1. Create a root directory on your local machine where you will clone Exercism repositories.
+//    Example: mkdir ~/ExercismRepos
+// 2. Clone the necessary Exercism repositories into this root directory. For example:
+//    cd ~/ExercismRepos
+//    git clone https://github.com/exercism/problem-specifications.git
+//    git clone https://github.com/exercism/awk.git
+//    (Clone any other repositories you need, like 'bash', 'java', etc.)
+// 3. When this query is loaded into Power Query, it will appear as a parameter
+//    (e.g., named 'ExercismReposRootPath' if you name the query itself that).
+// 4. IMPORTANT: Replace the placeholder string "~/IdeaProjects/Exercism"
+//    below with the actual absolute path to YOUR ROOT DIRECTORY containing your cloned Exercism repositories.
+//    Examples:
+//      - Windows: "C:\Users\YourUser\Documents\GitHub\MyExercismClones"
+//      - macOS/Linux: "/Users/YourUser/Documents/ExercismRepos"
+// 5. Other M queries designed to read from local clones will use this root path and then
+//    append the specific repository name (e.g., "problem-specifications") and file path.
+//
+// Note:
+// - Ensure the path is correct and that Power Query has the necessary permissions to access it.
+// - Users of these local-file-based queries will need to manage updating their local clones
+//   (e.g., using 'git pull' within each repository) to get the latest versions.
+let
+    // Current Value of the parameter.
+    // Replace the placeholder string below with the actual absolute path to your
+    // root directory containing local clones of Exercism repositories.
+    Source = "~/IdeaProjects/Exercism" meta [
+        // Metadata defining this query as a parameter:
+        IsParameterQuery = true,            
+        IsParameterQueryRequired = true,    
+        Type = "Text"
+    ]
+in
+    Source

--- a/src/local-api/GetLocalExerciseSlugs.pq
+++ b/src/local-api/GetLocalExerciseSlugs.pq
@@ -1,0 +1,18 @@
+// Description: Lists all exercise slugs (directory names) from the locally cloned
+//              'exercism/problem-specifications/exercises' directory.
+// Parameters: None
+// Returns:
+//   A list of text values, where each value is an exercise slug.
+// Depends on:
+//   - 'ExercismReposRootPath' parameter: The root path to the directory containing cloned Exercism repositories.
+
+() =>
+    let
+        ExercisesDirectoryPath = ExercismReposRootPath & "/problem-specifications/exercises/",
+        DirectoryContents = Folder.Contents(ExercisesDirectoryPath),
+        ExerciseFolders = Table.SelectRows(DirectoryContents, each [Attributes][Kind] = "Folder"),
+        ExerciseSlugs = ExerciseFolders[Name]
+    in
+        ExerciseSlugs
+
+        

--- a/src/local-api/GetLocalMetadata.pq
+++ b/src/local-api/GetLocalMetadata.pq
@@ -1,0 +1,78 @@
+// Function Name: GetLocalMetadata
+// Description: Fetches and parses the metadata.toml file for a given Exercism exercise slug
+//              from a locally cloned 'exercism/problem-specifications' repository.
+// Parameter:
+//   exerciseSlug (text): The slug of the exercise (e.g., "hello-world", "accumulate").
+// Returns:
+//   A record containing: title, blurb, source, source_url, and error_message (if any).
+// Depends on:
+//   - 'ExercismReposRootPath' parameter: The root path to the directory containing cloned Exercism repositories.
+(exerciseSlug as text) =>
+    let
+        // Default record structure, also used in case of errors
+        DefaultMetadataRecord = [title = null, blurb = null, source = null, source_url = null, error_message = null],
+        // Construct the full path to the metadata.toml file
+        // Assumes 'ExercismReposRootPath' parameter is defined and points to the root of your Exercism clones.
+        // And that 'problem-specifications' is a subdirectory within that root.
+        MetadataFilePath = ExercismReposRootPath
+            & "/problem-specifications/exercises/"
+            & exerciseSlug
+            & "/metadata.toml",
+        FetchedMetadata =
+            if MetadataFilePath = null then
+                DefaultMetadataRecord & [error_message = "ExercismReposRootPath parameter is not set or is invalid."]
+            else
+                try
+                    let
+                        FileContentBinary = File.Contents(MetadataFilePath),
+                        TextContent = Text.FromBinary(FileContentBinary, TextEncoding.Utf8),
+                        Lines = Lines.FromText(TextContent),
+                        // Inner helper to extract a value for a given key from TOML-like lines
+                        GetValueFromLines = (textLines as list, keyName as text) as nullable text =>
+                            let
+                                LinePrefixPattern = keyName & " = """,
+                                // e.g., blurb = "
+                                MatchingLineList = List.Select(textLines, each Text.StartsWith(_, LinePrefixPattern)),
+                                Value =
+                                    if List.IsEmpty(MatchingLineList) then
+                                        null
+                                    else
+                                        let
+                                            FullLine = List.First(MatchingLineList),
+                                            ValuePart = Text.Range(FullLine, Text.Length(LinePrefixPattern)),
+                                            TrimmedValue =
+                                                if Text.EndsWith(ValuePart, """") then
+                                                    Text.Start(ValuePart, Text.Length(ValuePart) - 1)
+                                                else
+                                                    ValuePart,
+                                            UnescapedValue = Text.Replace(
+                                                Text.Replace(TrimmedValue, "\\""", """"), "\\\\", "\"
+                                            )
+                                        in
+                                            UnescapedValue
+                            in
+                                Value,
+                        ExtractedTitle = GetValueFromLines(Lines, "title"),
+                        ExtractedBlurb = GetValueFromLines(Lines, "blurb"),
+                        ExtractedSource = GetValueFromLines(Lines, "source"),
+                        ExtractedSourceURL = GetValueFromLines(Lines, "source_url")
+                    in
+                        [
+                            title = ExtractedTitle,
+                            blurb = ExtractedBlurb,
+                            source = ExtractedSource,
+                            source_url = ExtractedSourceURL,
+                            error_message = null
+                            // No error if successful
+                        ]
+                    // If File.Contents fails (e.g., file not found) or parsing fails
+                otherwise
+                    DefaultMetadataRecord
+                        & [
+                            error_message = "Failed to read or parse local metadata.toml from: "
+                                & MetadataFilePath
+                                & ". Error: "
+                                & Error.Message
+                        ]
+    in
+        FetchedMetadata


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a configurable setting for specifying the local path to Exercism repositories.
	- Introduced the ability to list all available exercise slugs from a local Exercism repository.
	- Enabled retrieval and display of exercise metadata (title, blurb, source, source URL) from local files, with error handling for missing or malformed data.
- **Documentation**
	- Provided setup instructions for configuring the local repository path and keeping local clones updated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->